### PR TITLE
Add a Python testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
+dist: xenial   # required for Python >= 3.7
 language: python
 
 git:
   depth: false
 
 python:
+  - "3.5"
   - "3.6"
+  - "3.7"
 
 # jobs:
 #   include:

--- a/tests/dowel/test_tensor_board_output.py
+++ b/tests/dowel/test_tensor_board_output.py
@@ -56,7 +56,7 @@ class TestTensorBoardOutputMocked(TBOutputTest):
         foo = tf.constant(5)  # noqa: F841
         self.tensor_board_output.record(self.graph)
 
-        self.mock_writer.file_writer.add_event.assert_called_once()
+        assert self.mock_writer.file_writer.add_event.call_count == 1
 
     def test_record_scalar(self):
         foo = 5


### PR DESCRIPTION
This requires forcing TravisCI to use Ubuntu xenial images, according to
the documentation.