### PR TITLE
Remove tensorflow-probability from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ required = [
     'tabulate',
     'tensorboardX',
     'tensorflow',
-    'tensorflow-probability',
 ]
 
 extras = dict()


### PR DESCRIPTION
This is not an actual dependency.