### PR TITLE
Fix tests, add Tensorflow 2 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - pip install --upgrade pip  # some TravisCI images have outdated pip
 
 install:
-  - pip install .[dev]
+  - pip install .[all,dev]
 
 script:
   - scripts/travisci/check_precommit.sh

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,13 @@ required = [
     'scipy',
     'tabulate',
     'tensorboardX',
-    'tensorflow',
 ]
 
 extras = dict()
+
+extras['tensorflow'] = ['tensorflow']
+
+extras['all'] = list(set(sum(extras.values(), [])))
 
 # Development dependencies (*not* included in "all")
 extras['dev'] = [

--- a/tests/dowel/test_tensor_board_output.py
+++ b/tests/dowel/test_tensor_board_output.py
@@ -138,3 +138,26 @@ class TestTensorBoardOutputMocked(TBOutputTest):
         with self.assertRaises(ValueError):
             foo = np.zeros((3, 10))
             self.tensor_board_output.record(foo)
+
+    def test_record_tabular_without_tensorflow(self):
+        # Emulate not importing Tensorflow
+        self.tensor_board_output._tf = None
+        foo = 5
+        bar = 10.0
+        self.tabular.record('foo', foo)
+        self.tabular.record('bar', bar)
+        self.tensor_board_output.record(self.tabular, prefix='a/')
+        self.tensor_board_output.dump()
+
+        self.mock_writer.add_scalar.assert_any_call('foo', foo, 0)
+        self.mock_writer.add_scalar.assert_any_call('bar', bar, 0)
+
+    def test_types_accepted(self):
+        assert TabularInput in self.tensor_board_output.types_accepted
+        assert tf.Graph in self.tensor_board_output.types_accepted
+
+    def test_types_accepted_without_tensorflow(self):
+        # Emulate not importing Tensorflow
+        self.tensor_board_output._tf = None
+        assert TabularInput in self.tensor_board_output.types_accepted
+        assert tf.Graph not in self.tensor_board_output.types_accepted

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,3 @@
-
 import gc
 import unittest
 
@@ -24,13 +23,13 @@ class NullOutput(LogOutput):
 class TfGraphTestCase(unittest.TestCase):
     def setUp(self):
         self.graph = tf.Graph()
-        self.sess = tf.Session(graph=self.graph)
+        self.sess = tf.compat.v1.Session(graph=self.graph)
         self.sess.__enter__()
         logger.add_output(NullOutput())
 
     def tearDown(self):
         logger.remove_all()
-        if tf.get_default_session() is self.sess:
+        if tf.compat.v1.get_default_session() is self.sess:
             self.sess.__exit__(None, None, None)
         self.sess.close()
         # These del are crucial to prevent ENOMEM in the CI


### PR DESCRIPTION
Unfortunately, fixing the tests involves monkey patching `unittest`,
since it has bug. That bug is fixed in [CPython PR #4800](https://github.com/python/cpython/pull/4800), which has gone unmerged for over a year.