### PR TITLE
Add custom x axes to TensorBoard

### DIFF
--- a/src/dowel/__init__.py
+++ b/src/dowel/__init__.py
@@ -3,7 +3,7 @@
 This module instantiates a global logger singleton.
 """
 from dowel.histogram import Histogram
-from dowel.logger import Logger, LogOutput
+from dowel.logger import Logger, LogOutput, LoggerWarning
 from dowel.simple_outputs import StdOutput, TextOutput
 from dowel.tabular_input import TabularInput
 from dowel.csv_output import CsvOutput  # noqa: I100
@@ -19,6 +19,7 @@ __all__ = [
     'StdOutput',
     'TextOutput',
     'LogOutput',
+    'LoggerWarning',
     'TabularInput',
     'TensorBoardOutput',
     'logger',

--- a/src/dowel/__init__.py
+++ b/src/dowel/__init__.py
@@ -3,7 +3,7 @@
 This module instantiates a global logger singleton.
 """
 from dowel.histogram import Histogram
-from dowel.logger import Logger, LogOutput, LoggerWarning
+from dowel.logger import Logger, LoggerWarning, LogOutput
 from dowel.simple_outputs import StdOutput, TextOutput
 from dowel.tabular_input import TabularInput
 from dowel.csv_output import CsvOutput  # noqa: I100

--- a/src/dowel/logger.py
+++ b/src/dowel/logger.py
@@ -267,7 +267,10 @@ class Logger:
         """
         for output in self._outputs:
             if isinstance(output, output_type):
-                output.dump(step=step)
+                try:
+                    output.dump(step=step)
+                except LoggerWarning as e:
+                    self._warn(e.to_string())
 
     def dump_all(self, step=None):
         """Dump all outputs connected to the logger.
@@ -275,7 +278,10 @@ class Logger:
         :param step: The current run step.
         """
         for output in self._outputs:
-            output.dump(step=step)
+            try:
+                output.dump(step=step)
+            except LoggerWarning as e:
+                self._warn(e.to_string())
 
     @contextlib.contextmanager
     def prefix(self, prefix):
@@ -328,4 +334,6 @@ class Logger:
 class LoggerWarning(UserWarning):
     """Warning class for the Logger."""
 
-    pass
+    @abc.abstractmethod
+    def to_string(self):
+        raise NotImplementedError

--- a/src/dowel/logger.py
+++ b/src/dowel/logger.py
@@ -327,7 +327,3 @@ class Logger:
 
 class LoggerWarning(UserWarning):
     """Warning class for the Logger."""
-
-    @abc.abstractmethod
-    def to_string(self):
-        raise NotImplementedError

--- a/src/dowel/logger.py
+++ b/src/dowel/logger.py
@@ -267,10 +267,7 @@ class Logger:
         """
         for output in self._outputs:
             if isinstance(output, output_type):
-                try:
-                    output.dump(step=step)
-                except LoggerWarning as e:
-                    self._warn(e.to_string())
+                output.dump(step=step)
 
     def dump_all(self, step=None):
         """Dump all outputs connected to the logger.
@@ -278,10 +275,7 @@ class Logger:
         :param step: The current run step.
         """
         for output in self._outputs:
-            try:
-                output.dump(step=step)
-            except LoggerWarning as e:
-                self._warn(e.to_string())
+            output.dump(step=step)
 
     @contextlib.contextmanager
     def prefix(self, prefix):

--- a/src/dowel/tensor_board_output.py
+++ b/src/dowel/tensor_board_output.py
@@ -50,7 +50,7 @@ class TensorBoardOutput(LogOutput):
                  histogram_samples=1e3):
         if x_axis is None:
             assert not additional_x_axes, (
-                'You have to specify a x_axis if you want additional axes.')
+                'You have to specify an x_axis if you want additional axes.')
 
         additional_x_axes = additional_x_axes or []
 

--- a/src/dowel/tensor_board_output.py
+++ b/src/dowel/tensor_board_output.py
@@ -166,10 +166,6 @@ class TensorBoardOutput(LogOutput):
         self._warned_once.add(msg)
         return msg
 
-    def disable_warnings(self):
-        """Disable logger warnings for testing."""
-        self._disable_warnings = True
-
 
 class NonexistentAxesWarning(LoggerWarning):
     """Raise when the specified x axes do not exist in the tabular."""

--- a/src/dowel/tensor_board_output.py
+++ b/src/dowel/tensor_board_output.py
@@ -21,8 +21,8 @@ except ImportError:
     tf = None
 
 from dowel import Histogram
-from dowel import LogOutput
 from dowel import LoggerWarning
+from dowel import LogOutput
 from dowel import TabularInput
 from dowel.utils import colorize
 

--- a/src/dowel/tensor_board_output.py
+++ b/src/dowel/tensor_board_output.py
@@ -112,7 +112,7 @@ class TensorBoardOutput(LogOutput):
                 for axis in self._additional_x_axes:
                     if key is not axis and key in data.as_dict:
                         x = data.as_dict[axis]
-                        self._record_kv('{}@{}'.format(key, axis), value, x)
+                        self._record_kv('{}/{}'.format(key, axis), value, x)
             else:
                 self._record_kv(key, value, step)
             data.mark(key)

--- a/tests/dowel/test_tensor_board_output.py
+++ b/tests/dowel/test_tensor_board_output.py
@@ -202,3 +202,19 @@ class TestTensorBoardOutputXAxesMocked(TBOutputTest):
         self.mock_writer.add_scalar.assert_any_call('foo@bar', foo, bar)
         self.mock_writer.add_scalar.assert_any_call('bar', bar, foo)
         assert self.mock_writer.add_scalar.call_count == 2
+
+    def test_record_scalar_nonexistent_axis(self):
+        self.tensor_board_output._default_step = 0
+        self.tensor_board_output._x_axis = 'qux'
+        self.tensor_board_output._additional_x_axes = ['bar']
+
+        foo = 5
+        bar = 10.0
+        self.tabular.record('foo', foo)
+        self.tabular.record('bar', bar)
+        self.tensor_board_output.record(self.tabular)
+        self.tensor_board_output.dump()
+
+        self.mock_writer.add_scalar.assert_any_call('foo', foo, 0)
+        self.mock_writer.add_scalar.assert_any_call('bar', bar, 0)
+        assert self.mock_writer.add_scalar.call_count == 2

--- a/tests/dowel/test_tensor_board_output.py
+++ b/tests/dowel/test_tensor_board_output.py
@@ -199,7 +199,7 @@ class TestTensorBoardOutputXAxesMocked(TBOutputTest):
         self.tensor_board_output.record(self.tabular)
         self.tensor_board_output.dump()
 
-        self.mock_writer.add_scalar.assert_any_call('foo@bar', foo, bar)
+        self.mock_writer.add_scalar.assert_any_call('foo/bar', foo, bar)
         self.mock_writer.add_scalar.assert_any_call('bar', bar, foo)
         assert self.mock_writer.add_scalar.call_count == 2
 


### PR DESCRIPTION
This PR adds support for custom x-axes to the TensorBoard scalar plot. The axis names are specified in the tensorboard output constructor. 
```
class TensorBoardOutput(LogOutput):
    def __init__(self,
                 log_dir,
                 x_axes=None,
                 flush_secs=120,
                 histogram_samples=1e3): 
```

When `x_axes` is `None`, it falls back to use iterations as the x-axis. 
If any x_axis is not present in the scalar tabular. A warning will be logged to the console.
If all x_axes are not present, it falls back to use iteration as the x-axis.

Screenshots of an experiment with `Epoch` and `TotalEnvSteps` as x-axes.
![Screenshot from 2019-11-22 20-43-24](https://user-images.githubusercontent.com/8409272/69473396-f2d49780-0d68-11ea-8ec9-012e538b65ac.png)
![Screenshot from 2019-11-22 20-43-43](https://user-images.githubusercontent.com/8409272/69473399-f405c480-0d68-11ea-92ee-f978a3cb6bee.png)

I will open a separate PR in garage repo to set `TotalEnvSteps` as the default x-axis. 
