### PR TITLE
Fix #47(Inconsistent tabularInput Keys + test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,10 @@ Sessionx.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# code editor header info
+.vscode/
+
+# log outputs
+*.csv
+tensorboard_logdir/

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -57,6 +57,27 @@ class TestCsvOutput:
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 
+    def test_key_inconsistent(self):
+        for i in range(4):
+            self.tabular.record('itr', i)
+            self.tabular.record('loss', 100.0 / (2 + i))
+
+            # the addition of new data to tabular breaks logging to CSV
+            if i > 0:
+                self.tabular.record('new_data', i)
+
+            # this should not produce a warning, because we only warn once
+            self.csv_output.record(self.tabular)
+            self.csv_output.dump()
+
+        correct = [
+            {'itr': str(0), 'loss': str(100.0/2.), 'new_data': ''},
+            {'itr': str(1), 'loss': str(100.0/3.), 'new_data': str(1)},
+            {'itr': str(2), 'loss': str(100.0/4.), 'new_data': str(2)},
+            {'itr': str(3), 'loss': str(100.0/5.), 'new_data': str(3)}
+        ]
+        self.assert_csv_matches(correct)
+        
     def test_empty_record(self):
         self.csv_output.record(self.tabular)
         assert not self.csv_output._writer


### PR DESCRIPTION
The current issue #45 is caused by inconsistent keys in `tabularInput` with `csvOutput` headers. To fix this: 
1)  Read the existing log file
2) Update the csv Dictwriter with the new header using union
- Union of `tabularInput`'s and `csvOutput`'s header is used to make sure all keys from both instances are captured
3) Write the same log file with new key headers and old data. If the value of new key is missing, the cell is left blank.

The cons of this solution:
- The csv log file is read and write to update the inconsistent key headers. It may be time-consuming to handle a large number of csv log files because of the heavy I/O. To ensure the I/O is as efficient as possible, all file reading and writing is done in RAM and file is closed upon used.

A better approach can be:
- Expand the header on-the-go as a new key(s) is encountered. Write the log file with the new header exactly once. 

rlworkgroup#45
@avnishn
@zequnyu