### PR TITLE
Fix Inconsistent TabularInput keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,9 @@ tags
 
 # MacOS
 .DS_Store
+# code editor header info
+.vscode/
+
+# log outputs
+*.csv
+tensorboard_logdir/

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -1,10 +1,9 @@
 """A `dowel.logger.LogOutput` for CSV files."""
 import csv
-import warnings
+import os
 
 from dowel import TabularInput
 from dowel.simple_outputs import FileOutput
-from dowel.utils import colorize
 
 
 class CsvOutput(FileOutput):
@@ -17,8 +16,7 @@ class CsvOutput(FileOutput):
         super().__init__(file_name)
         self._writer = None
         self._fieldnames = None
-        self._warned_once = set()
-        self._disable_warnings = False
+        self._filename = file_name
 
     @property
     def types_accepted(self):
@@ -30,24 +28,37 @@ class CsvOutput(FileOutput):
         if isinstance(data, TabularInput):
             to_csv = data.as_primitive_dict
 
-            if not to_csv.keys() and not self._writer:
-                return
-
             if not self._writer:
                 self._fieldnames = set(to_csv.keys())
-                self._writer = csv.DictWriter(
-                    self._log_file,
-                    fieldnames=self._fieldnames,
-                    extrasaction='ignore')
+                self._writer = csv.DictWriter(self._log_file,
+                                              fieldnames=self._fieldnames,
+                                              restval='',
+                                              extrasaction='raise')
                 self._writer.writeheader()
 
             if to_csv.keys() != self._fieldnames:
-                self._warn('Inconsistent TabularInput keys detected. '
-                           'CsvOutput keys: {}. '
-                           'TabularInput keys: {}. '
-                           'Did you change key sets after your first '
-                           'logger.log(TabularInput)?'.format(
-                               set(self._fieldnames), set(to_csv.keys())))
+                # Close existing log file
+                super().close()
+
+                # Move log file to temp file
+                temp_file_name = '{}.tmp'.format(self._filename)
+                os.replace(self._filename, temp_file_name)
+
+                # Add new keys to fieldnames
+                self._fieldnames = (set(self._fieldnames) | set(to_csv.keys()))
+
+                # Open a new copy of the log file
+                self._log_file = open(self._filename, 'w')
+                self._writer = csv.DictWriter(self._log_file,
+                                              fieldnames=self._fieldnames,
+                                              restval='',
+                                              extrasaction='raise')
+
+                # Transfer data from temp file
+                with open(temp_file_name, 'r') as temp_file:
+                    self._writer.writeheader()
+                    for row in csv.DictReader(temp_file):
+                        self._writer.writerow(row)
 
             self._writer.writerow(to_csv)
 
@@ -55,25 +66,3 @@ class CsvOutput(FileOutput):
                 data.mark(k)
         else:
             raise ValueError('Unacceptable type.')
-
-    def _warn(self, msg):
-        """Warns the user using warnings.warn.
-
-        The stacklevel parameter needs to be 3 to ensure the call to logger.log
-        is the one printed.
-        """
-        if not self._disable_warnings and msg not in self._warned_once:
-            warnings.warn(
-                colorize(msg, 'yellow'), CsvOutputWarning, stacklevel=3)
-        self._warned_once.add(msg)
-        return msg
-
-    def disable_warnings(self):
-        """Disable logger warnings for testing."""
-        self._disable_warnings = True
-
-
-class CsvOutputWarning(UserWarning):
-    """Warning class for CsvOutput."""
-
-    pass

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -1,10 +1,10 @@
 import csv
+import os
 import tempfile
 
 import pytest
 
 from dowel import CsvOutput, TabularInput
-from dowel.csv_output import CsvOutputWarning
 
 
 class TestCsvOutput:
@@ -34,62 +34,70 @@ class TestCsvOutput:
             {'foo': str(foo * 2), 'bar': str(bar * 2)},
         ]  # yapf: disable
         self.assert_csv_matches(correct)
+        assert not os.path.exists('{}.tmp'.format(self.log_file.name))
 
-    def test_record_inconsistent(self):
-        foo = 1
-        bar = 10
-        self.tabular.record('foo', foo)
-        self.csv_output.record(self.tabular)
-        self.tabular.record('foo', foo * 2)
-        self.tabular.record('bar', bar * 2)
+    def test_key_inconsistent(self):
+        for i in range(4):
+            self.tabular.record('itr', i)
+            self.tabular.record('loss', 100.0 / (2 + i))
 
-        with pytest.warns(CsvOutputWarning):
+            # the addition of new data to tabular breaks logging to CSV
+            if i > 0:
+                self.tabular.record('x', i)
+
+            if i > 1:
+                self.tabular.record('y', i + 1)
+
+            # this should not produce a warning, because we only warn once
             self.csv_output.record(self.tabular)
+            self.csv_output.dump()
 
-        # this should not produce a warning, because we only warn once
-        self.csv_output.record(self.tabular)
-
-        self.csv_output.dump()
-
-        correct = [
-            {'foo': str(foo)},
-            {'foo': str(foo * 2)},
-        ]  # yapf: disable
+        correct = [{
+            'itr': str(0),
+            'loss': str(100.0 / 2.),
+            'x': '',
+            'y': ''
+        }, {
+            'itr': str(1),
+            'loss': str(100.0 / 3.),
+            'x': str(1),
+            'y': ''
+        }, {
+            'itr': str(2),
+            'loss': str(100.0 / 4.),
+            'x': str(2),
+            'y': str(3)
+        }, {
+            'itr': str(3),
+            'loss': str(100.0 / 5.),
+            'x': str(3),
+            'y': str(4)
+        }]
         self.assert_csv_matches(correct)
 
     def test_empty_record(self):
         self.csv_output.record(self.tabular)
-        assert not self.csv_output._writer
+        self.csv_output.dump()
 
         foo = 1
         bar = 10
         self.tabular.record('foo', foo)
         self.tabular.record('bar', bar)
         self.csv_output.record(self.tabular)
-        assert not self.csv_output._warned_once
+        self.csv_output.dump()
+        # Empty lines are not recorded
+        self.assert_csv_matches([{'foo': str(foo), 'bar': str(bar)}])
 
     def test_unacceptable_type(self):
         with pytest.raises(ValueError):
             self.csv_output.record('foo')
 
-    def test_disable_warnings(self):
-        foo = 1
-        bar = 10
-        self.tabular.record('foo', foo)
-        self.csv_output.record(self.tabular)
-        self.tabular.record('foo', foo * 2)
-        self.tabular.record('bar', bar * 2)
-
-        self.csv_output.disable_warnings()
-
-        # this should not produce a warning, because we disabled warnings
-        self.csv_output.record(self.tabular)
-
     def assert_csv_matches(self, correct):
         """Check the first row of a csv file and compare it to known values."""
         with open(self.log_file.name, 'r') as file:
-            reader = csv.DictReader(file)
+            contents = list(csv.DictReader(file))
+            assert len(contents) == len(correct)
 
-            for correct_row in correct:
-                row = next(reader)
-                assert row == correct_row
+            for row, correct_row in zip(contents, correct):
+                assert sorted(list(row.items())) == sorted(
+                    list(correct_row.items()))


### PR DESCRIPTION
This fixes #47.

This implementation is derived from Iris's application version, with a few minor fixes and an extension to the test.